### PR TITLE
use home assistant image url

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.0.16: better image update
 0.0.15: Remove camera_thumbnail
 0.0.14: Add light switch to streaming
 0.0.13: Add light switch

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -2,7 +2,7 @@
     "aarlo-glance": {
         "changelog": "https://github.com/twrecked/lovelace-hass-aarlo/blob/master/changelog",
         "remote_location": "https://raw.githubusercontent.com/twrecked/lovelace-hass-aarlo/master/dist/hass-aarlo.js",
-        "version": "0.0.15",
+        "version": "0.0.16",
         "visit_repo": "https://github.com/twrecked/lovelace-hass-aarlo"
     }
 }

--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -356,7 +356,8 @@ class AarloGlance extends LitElement {
     }
 
     changed() {
-        this._change++
+        this._change = new Date().getTime();
+        return this._change;
     }
 
     getState(_id, default_value = '') {
@@ -506,7 +507,7 @@ class AarloGlance extends LitElement {
         // has happened.
         if ( camera.state !== this._s.cameraState ) {
             if ( this._s.cameraState === 'taking snapshot' ) {
-                //console.log( 'updating1 ' + this._s.cameraName + ':' + this._s.cameraState + '-->' + camera.state );
+                //console.log( 'snapshot ' + this._s.cameraName + ':' + this._s.cameraState + '-->' + camera.state );
                 this.updateCameraImageSrc();
                 this.updateCameraImageSourceLater(5);
                 this.updateCameraImageSourceLater(10)
@@ -939,16 +940,16 @@ class AarloGlance extends LitElement {
                 type: "aarlo_snapshot_image",
                 entity_id: this._s.cameraId,
             });
-            this._image = `data:${contentType};base64, ${content}`;
+            // no longer wait for return...
+            // add aarlo_take_snapshot
         } catch (err) {
-            this._image = null
         }
     }
 
     async updateCameraImageSrc() {
         const camera = this.getState(this._s.cameraId,'unknown');
         if ( camera != 'unknown' ) {
-            this._image = camera.attributes.last_thumbnail;
+            this._image = camera.attributes.entity_picture + "&t=" + this.changed();
         } else {
             this._image = null;
         }
@@ -1178,3 +1179,4 @@ s.onload = function() {
 };
 document.head.appendChild(s);
 
+# vim: set expandtab:ts=4:sw=4


### PR DESCRIPTION

Better image handling. Previous PR used arlo server directly which broke the image display because  snapshot images expire after about a day.

This one use `api/camera_proxy/camera.???` url instead.
