### PR TITLE
Name parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ You only need one of these. `entity` is the full camera entity id - for
 example, `camera.aarlo_front_door` while `camera` is just the name portion -
 for example, `aarlo_front_door`.
 
+### Naming
+If you don't change entity names you don't need to worry about this.
+
 The code tries to be smart about mapping cameras to device names and as long as
 you follow certain rules the card can automatically generate device names.
 
@@ -119,12 +122,12 @@ Given the entity id `camera.front_door`, you get a `prefix` of "" and a
 `camera_name` of "front_door".
 
 The device names are calculated as:
-* motion device; 'binary_sensor.' + prefix + 'motion_' + camera_name
-* sound device; 'binary_sensor.' + prefix + 'sound_' + camera_name;
-* battery device; 'sensor.' + prefix + 'battery_level_' + camera_name;
-* signal_device; 'sensor.' + prefix + 'signal_strength_' + camera_name;
-* capture_today_device; 'sensor.' + prefix + 'captured_today_' + camera_name;
-* last_capture_device; 'sensor.' + prefix + 'last_' + camera_name;
+* motion device = `binary_sensor.${prefix}motion_${camera_name}`
+* sound device = `binary_sensor.${prefix}sound_${camera_name}`
+* battery device = `sensor.${prefix}battery_level_${camera_name}`
+* signal_device = `sensor.${prefix}signal_strength_${camera_name}`
+* capture_today_device = `sensor.${prefix}captured_today_${camera_name}`
+* last_capture_device = `sensor.${prefix}last_${camera_name}`
 
 If you rename any of the `aarlo` using a different scheme you will need to
 provide the full device name to get motion, sound, battery, signal, capture or

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The card supports the following configuration items:
 | Name          | Type          | Default        | Supported options                                                                             | Description                                                                                                  |
 | ------------- | ------------- | -------------- | ---------------------------------------------------------------------------------------       | -----------------------------------------                                                                    |
 | type          | string        | **required**   | `custom:aarlo-glance`                                                                         |                                                                                                              |
-| entity        | string        | **required**   | camera entity_id                                                                              |                                                                                                              |
+| entity        | string        | **required**   | full camera entity_id                                                                         |                                                                                                              |
+| camera        | string        | **required**   | camera name                                                                                   |                                                                                                              |
 | name          | string        |                | Display Name                                                                                  |                                                                                                              |
 | show          | string list   | **required**   | [motion, sound, snapshot, battery_level, signal_strength, captured_today, image_date, on_off] | all items are optional but you must provide at least 1                                                       |
 | hide          | string list   |                | [title, status, date ]                                                                        | Hide this information from the card.                                                                         |
@@ -102,6 +103,34 @@ The card supports the following configuration items:
 | signal_id     | string        |                |                                                                                               | Override the calculated signal device name                                                                   |
 | capture_id    | string        |                |                                                                                               | Override the calculated captured today device name                                                           |
 | last_id       | string        |                |                                                                                               | Override the calculated last captured device name                                                            |
+
+### `entity` vs `camera`
+You only need one of these. `entity` is the full camera entity id - for
+example, `camera.aarlo_front_door` while `camera` is just the name portion -
+for example, `aarlo_front_door`.
+
+The code tries to be smart about mapping cameras to device names and as long as
+you follow certain rules the card can automatically generate device names.
+
+Given the entity id `camera.aarlo_front_door`, you get a `prefix` of "aarlo_"
+and a `camera_name` of "front_door".
+
+Given the entity id `camera.front_door`, you get a `prefix` of "" and a
+`camera_name` of "front_door".
+
+The device names are calculated as:
+* motion device; 'binary_sensor.' + prefix + 'motion_' + camera_name
+* sound device; 'binary_sensor.' + prefix + 'sound_' + camera_name;
+* battery device; 'sensor.' + prefix + 'battery_level_' + camera_name;
+* signal_device; 'sensor.' + prefix + 'signal_strength_' + camera_name;
+* capture_today_device; 'sensor.' + prefix + 'captured_today_' + camera_name;
+* last_capture_device; 'sensor.' + prefix + 'last_' + camera_name;
+
+If you rename any of the `aarlo` using a different scheme you will need to
+provide the full device name to get motion, sound, battery, signal, capture or
+last capture notifications to work. See the corresponding `*_id` configuration
+item.
+
 
 ### `show` options
 * `motion`: an icon that indicates when motion is detected
@@ -127,9 +156,6 @@ binary_sensor:
     - motion
 ```
 
-If you rename any of the `aarlo` devices you will need to provide the full
-device name to get motion, sound, battery, signal, capture or last capture
-notifications to work. See the corresponding `*_id` configuration item.
 
 
 #### Example

--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.1.3: better name parsing
        added camera on/off support
 0.1.2: added mpeg-dash support
 0.1.1: added missing update call

--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -876,9 +876,10 @@ class AarloGlance extends LitElement {
 
     setConfig(config) {
 
+        // find camera
         let camera = null;
         if( config.entity ) {
-            camera = config.entity.replace( 'camera.aarlo_','' );
+            camera = config.entity.replace( 'camera.','' );
         }
         if( config.camera ) {
             camera = config.camera;
@@ -890,19 +891,29 @@ class AarloGlance extends LitElement {
             this.throwError( 'missing show components' );
         }
 
+        // see if aarlo prefix, remove from custom names if not present
+        let prefix = "";
+        if ( camera.startsWith( 'aarlo_','' ) ) {
+            camera = camera.replace( 'aarlo_','' )
+            prefix = "aarlo_"
+        }
+        if( config.prefix ) {
+            prefix = config.prefix;
+        }
+
         // save new config and reset decoration properties
         this._config = config;
         this.checkConfig();
         this.resetStatuses();
 
         // camera and sensors
-        this._s.cameraId  = config.camera_id ? config.camera_id : 'camera.aarlo_' + camera;
-        this._s.motionId  = config.motion_id ? config.motion_id : 'binary_sensor.aarlo_motion_' + camera;
-        this._s.soundId   = config.sound_id ? config.sound_id : 'binary_sensor.aarlo_sound_' + camera;
-        this._s.batteryId = config.battery_id ? config.battery_id : 'sensor.aarlo_battery_level_' + camera;
-        this._s.signalId  = config.signal_id ? config.signal_id : 'sensor.aarlo_signal_strength_' + camera;
-        this._s.captureId = config.capture_id ? config.capture_id : 'sensor.aarlo_captured_today_' + camera;
-        this._s.lastId    = config.last_id ? config.last_id : 'sensor.aarlo_last_' + camera;
+        this._s.cameraId  = config.camera_id ? config.camera_id : 'camera.' + prefix + camera;
+        this._s.motionId  = config.motion_id ? config.motion_id : 'binary_sensor.' + prefix + 'motion_' + camera;
+        this._s.soundId   = config.sound_id ? config.sound_id : 'binary_sensor.' + prefix + 'sound_' + camera;
+        this._s.batteryId = config.battery_id ? config.battery_id : 'sensor.' + prefix + 'battery_level_' + camera;
+        this._s.signalId  = config.signal_id ? config.signal_id : 'sensor.' + prefix + 'signal_strength_' + camera;
+        this._s.captureId = config.capture_id ? config.capture_id : 'sensor.' + prefix + 'captured_today_' + camera;
+        this._s.lastId    = config.last_id ? config.last_id : 'sensor.' + prefix + 'last_' + camera;
 
         // door definition
         this._s.doorId     = config.door ? config.door: null;


### PR DESCRIPTION

Better name parsing. Code will now recognise cameras without an aarlo_ in their name and
generate better automatic id names.
