### PR TITLE
use hassUrl() for image path to support cast

### DIFF
--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -1505,7 +1505,10 @@ class AarloGlance extends HTMLElement {
      */
     generateImageURL() {
         const camera = this._getState(this.cc.id,'unknown');
-        this.cs.image = camera.attributes.entity_picture + "&t=" + new Date().getTime()
+        
+        // For cast compatibility, use hassUrl()
+        // matches https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/components/hui-image.ts
+        this.cs.image = this._hass.hassUrl(camera.attributes.entity_picture + "&t=" + new Date().getTime()) 
         this.cs.imageBase = camera.attributes.entity_picture
     }
 


### PR DESCRIPTION
Follows pattern from hui-image.ts https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/components/hui-image.ts

resolves: https://github.com/twrecked/lovelace-hass-aarlo/issues/129