### PR TITLE
Add null check.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.2.6: add null check
 0.2.0b5: fix plugin icon
 0.2.0b4: replace alert() with logs
        use HA icons

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -2,7 +2,7 @@
     "aarlo-glance": {
         "changelog": "https://github.com/twrecked/lovelace-hass-aarlo/blob/master/changelog",
         "remote_location": "https://raw.githubusercontent.com/twrecked/lovelace-hass-aarlo/master/dist/hass-aarlo.js",
-        "version": "0.2.0",
+        "version": "0.2.6",
         "visit_repo": "https://github.com/twrecked/lovelace-hass-aarlo"
     }
 }

--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -119,7 +119,7 @@ class AarloGlance extends LitElement {
         this._ready = false
         this._hass = null;
         this._config = null;
-        this._version = "0.2.0b5"
+        this._version = "0.2.6"
 
         // Internationalisation.
         this._i = null
@@ -1816,7 +1816,7 @@ class AarloGlance extends LitElement {
             this._show( id )
 
             // highlight is on at this level and we have something?
-            if( show_triggers && video.trigger !== null ) {
+            if( show_triggers && video.trigger !== null && video.trigger_region !== null ) {
                 const coords = video.trigger_region.split(",")
 
                 let box = this._element( bid )


### PR DESCRIPTION
Fix `Cannot read properties of null (reading 'split')` issue.

It looks like Arlo change the back end so I needed to add another check.
