### PR TITLE
Add null check.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+0.3.0a2: check for region null value
+  support chromecast devices
 0.3.0a1: set up stream view programatically
   add both locks and lights to the stream view
   remove old configuration support

--- a/custom_cards.json
+++ b/custom_cards.json
@@ -2,7 +2,7 @@
     "aarlo-glance": {
         "changelog": "https://github.com/twrecked/lovelace-hass-aarlo/blob/master/changelog",
         "remote_location": "https://raw.githubusercontent.com/twrecked/lovelace-hass-aarlo/master/dist/hass-aarlo.js",
-        "version": "0.2.0",
+        "version": "0.3.0a2",
         "visit_repo": "https://github.com/twrecked/lovelace-hass-aarlo"
     }
 }

--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -105,7 +105,7 @@ class AarloGlance extends HTMLElement {
         super();
 
         // current version
-        this._version = "0.3.0a1"
+        this._version = "0.3.0a2"
 
         // State and config.
         this._ready = "stopped"
@@ -1683,7 +1683,7 @@ class AarloGlance extends HTMLElement {
             this._show( id )
 
             // highlight is on at this level and we have something?
-            if( show_triggers && video.trigger !== null ) {
+            if( show_triggers && video.trigger !== null && video.trigger_region !== null ) {
                 const coords = video.trigger_region.split(",")
 
                 let box = this._element( bid )


### PR DESCRIPTION
Fix `Cannot read properties of null (reading 'split')` issue.

It looks like Arlo changed the back end so I needed to add another check.
