### PR TITLE
Use default power icon for the button to turn cameras on and off

### DIFF
--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -765,9 +765,9 @@ class AarloGlance extends HTMLElement {
         }
 
         if ( this.cs.state === 'off' ) {
-            this.cs.details.onoff = _tsi(this._i.image.turn_camera_on, 'state-on', 'mdi:camera')
+            this.cs.details.onoff = _tsi(this._i.image.turn_camera_on, 'state-on', 'mdi:power')
         } else {
-            this.cs.details.onoff = _tsi(this._i.image.turn_camera_off, '', 'mdi:camera-off')
+            this.cs.details.onoff = _tsi(this._i.image.turn_camera_off, '', 'mdi:power')
         }
 
         if(this.cs.state !== 'off') {


### PR DESCRIPTION
The `mdi:camera` and `mdi:camera-off` icons look really similar to the `mdi:camera-enhance` icon that is used for the snapshot button, which is confusing if you're like me and have them configured to be next to each other in the card.

Thanks for all your work on this integration (and [`hass-arlo`](https://github.com/twrecked/hass-aarlo)!)