### PR TITLE
fix: state-error before state-warn

### DIFF
--- a/dist/hass-aarlo.js
+++ b/dist/hass-aarlo.js
@@ -784,7 +784,7 @@ class AarloGlance extends HTMLElement {
             const prefix = camera.attributes.charging ? 'battery-charging' : 'battery';
             this.cs.details.battery = _tsi(
                 `${this._i.status.battery_strength}: ${battery.state}%`,
-                battery.state < 25 ? 'state-warn' : ( battery.state < 15 ? 'state-error' : 'state-update' ),
+                battery.state < 15 ? 'state-error' : ( battery.state < 25 ? 'state-warn' : 'state-update' ),
                 `mdi:${prefix}` + (battery.state < 10 ? '-outline' :
                             (battery.state > 90 ? '' : '-' + Math.round(battery.state/10) + '0' ))
             )


### PR DESCRIPTION
**Problem:** Using an example battery level of 9% ... previously _I believe_ this would only return "state-warn" and never return "state-error"

**Solution**   I'm not terribly well versed in js, so while this worked for _me_ and I tested a couple ways to validate my assumptions, I don't want to present this change as knowing more than I do. 

Anyway, hopefully this is a useful submission. If it's off for whatever reason, feel free to discard.